### PR TITLE
added $length to $mapped

### DIFF
--- a/helpers.operators.js
+++ b/helpers.operators.js
@@ -98,7 +98,10 @@ if (typeof UI !== 'undefined') {
       }
     }
     
+    var $length = arr.length;
+    
     var mappedArray = arr.map(function(item,index) {
+      item.$length = $length;
       item.$index = index;
       item.$first = index === 0;
       item.$last  = index === arr.length-1;


### PR DESCRIPTION
I often end up requiring the length of an array along with its index information (e.g. *item 1/7*), hence this pull request.