### PR TITLE
Added support for unlimited amount of parameters and optionally pass …

### DIFF
--- a/helpers.operators.js
+++ b/helpers.operators.js
@@ -36,12 +36,24 @@ if (typeof UI !== 'undefined') {
       return (a !== b); //Only text, numbers, boolean - not array & objects
     });
 
-    UI.registerHelper('$in', function (a, b, c, d) {
-      return ( a === b || a === c || a === d);
+    var slice = [].slice;
+
+    UI.registerHelper('$in', function() {
+      var a, b;
+      a = arguments[0], b = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+      if (b.length === 1 && Array.isArray(b[0])) {
+        b = b[0];
+      }
+      return b.indexOf(a) > -1;
     });
 
-    UI.registerHelper('$nin', function (a, b, c, d) {
-      return ( a !== b && a !== c && a !== d);
+    UI.registerHelper('$nin', function() {
+      var a, b;
+      a = arguments[0], b = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+      if (b.length === 1 && Array.isArray(b[0])) {
+        b = b[0];
+      }
+      return b.indexOf(a) === -1;
     });
 
     UI.registerHelper('$exists', function (a) {


### PR DESCRIPTION
…in an array for the second parameter.

See [this codepen for a demo](http://codepen.io/Zodiase/full/KdxzdY/).

I wrote the code in CoffeeScript and copy-pasted the converted version into the file.
The original code I wrote:
```CoffeeScript
UI.registerHelper('$in', (a, b...) ->
  if b.length == 1 and Array.isArray(b[0])
    b = b[0]
  return b.indexOf(a) > -1
)

UI.registerHelper('$nin', (a, b...) ->
  if b.length == 1 and Array.isArray(b[0])
    b = b[0]
  return b.indexOf(a) == -1
)
```

Usage:
```
// Finds if a is in array b.
function $in (Mixed a, Array b) {}

// Finds if a is in any of the other parameters. There is no limit to how many parameters could be passed in.
function $in (Mixed a[, Mixed b[, Mixed c[, ...]]]) {}

// $nin is similar.
```

This change does not break compatibility IMO.